### PR TITLE
remove Email application from GrapheneOS

### DIFF
--- a/target/product/handheld_product.mk
+++ b/target/product/handheld_product.mk
@@ -27,7 +27,6 @@ PRODUCT_PACKAGES += \
     Camera2 \
     Contacts \
     DeskClock \
-    Email \
     ExactCalculator \
     Gallery2 \
     LatinIME \

--- a/target/product/mainline_arm64.mk
+++ b/target/product/mainline_arm64.mk
@@ -37,7 +37,6 @@ PRODUCT_ARTIFACT_PATH_REQUIREMENT_WHITELIST += \
   system/app/DeskClock/DeskClock.apk \
   system/app/DeskClock/oat/arm64/DeskClock.odex \
   system/app/DeskClock/oat/arm64/DeskClock.vdex \
-  system/app/Email/Email.apk \
   system/app/Gallery2/Gallery2.apk \
   system/app/LatinIME/LatinIME.apk \
   system/app/LatinIME/oat/arm64/LatinIME.odex \


### PR DESCRIPTION
removes the email package from GrapheneOS

addresses https://github.com/GrapheneOS/os_issue_tracker/issues/47