### PR TITLE
replace webview with TrichromeWebView again

### DIFF
--- a/target/product/media_product.mk
+++ b/target/product/media_product.mk
@@ -22,4 +22,4 @@ $(call inherit-product, $(SRC_TARGET_DIR)/product/base_product.mk)
 
 # /product packages
 PRODUCT_PACKAGES += \
-    webview \
+    TrichromeWebView \


### PR DESCRIPTION
This reverts commit e32a5b11d27456cba046031091166b2836d9e57d.

Opening PDF Viewer, I was able to browse PDFs, and I see this in logcat:

```
10-06 12:18:42.353  3797  3797 I WebViewFactory: Loading org.grapheneos.vanadium.webview version 86.0.4240.75 (code 424007534)
```

Also used a browser app that uses WebView without problems