### PR TITLE
disable OpenGL preloading

### DIFF
--- a/core/main.mk
+++ b/core/main.mk
@@ -250,6 +250,9 @@ endif
 ### between the build variants
 ###
 
+# Disable OpenGL preloading
+ADDITIONAL_BUILD_PROPERTIES += ro.zygote.disable_gl_preload=1
+
 is_sdk_build :=
 
 ifneq ($(filter sdk win_sdk sdk_addon,$(MAKECMDGOALS)),)


### PR DESCRIPTION
This is still valid on newer Android versions. See: https://source.android.com/devices/graphics/renderer