### PR TITLE
Never set Windows HOST_CROSS variables

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -4424,6 +4424,11 @@ INTERNAL_OTATOOLS_PACKAGE_FILES += \
   $(sort $(shell find external/vboot_reference/tests/devkeys -type f))
 endif
 
+# Factory images
+INTERNAL_OTATOOLS_PACKAGE_FILES += \
+  device/common/clear-factory-images-variables.sh \
+  device/common/generate-factory-images-common.sh
+
 INTERNAL_OTATOOLS_RELEASETOOLS := \
   $(sort $(shell find build/make/tools/releasetools -name "*.pyc" -prune -o \
       \( -type f -o -type l \) -print))

--- a/core/Makefile
+++ b/core/Makefile
@@ -4429,6 +4429,15 @@ INTERNAL_OTATOOLS_PACKAGE_FILES += \
   device/common/clear-factory-images-variables.sh \
   device/common/generate-factory-images-common.sh
 
+# GrapheneOS scripts
+INTERNAL_OTATOOLS_PACKAGE_FILES += \
+  script/common.sh \
+  script/decrypt_keys.sh \
+  script/encrypt_keys.sh \
+  script/generate_metadata.py \
+  script/release.sh \
+  script/signify_prehash.sh
+
 INTERNAL_OTATOOLS_RELEASETOOLS := \
   $(sort $(shell find build/make/tools/releasetools -name "*.pyc" -prune -o \
       \( -type f -o -type l \) -print))

--- a/core/board_config.mk
+++ b/core/board_config.mk
@@ -147,10 +147,7 @@ _board_true_false_vars := $(_build_broken_var_list)
 _board_strip_readonly_list += $(_build_broken_var_list) \
   BUILD_BROKEN_NINJA_USES_ENV_VARS
 
-# Conditional to building on linux, as dex2oat currently does not work on darwin.
-ifeq ($(HOST_OS),linux)
-  WITH_DEXPREOPT := true
-endif
+WITH_DEXPREOPT := true
 
 # ###############################################################
 # Broken build defaults

--- a/core/combo/TARGET_linux-arm.mk
+++ b/core/combo/TARGET_linux-arm.mk
@@ -33,7 +33,7 @@
 KNOWN_ARMv8_CORES := cortex-a53 cortex-a53.a57 cortex-a55 cortex-a73 cortex-a75 cortex-a76
 KNOWN_ARMv8_CORES += kryo kryo385 exynos-m1 exynos-m2
 
-KNOWN_ARMv82a_CORES := cortex-a55 cortex-a75 kryo385
+KNOWN_ARMv82a_CORES := cortex-a55 cortex-a75 cortex-a76 kryo385
 
 ifeq (,$(strip $(TARGET_$(combo_2nd_arch_prefix)CPU_VARIANT)))
   TARGET_$(combo_2nd_arch_prefix)CPU_VARIANT := generic

--- a/core/config_sanitizers.mk
+++ b/core/config_sanitizers.mk
@@ -508,3 +508,9 @@ ifneq ($(findstring fsanitize,$(my_cflags)),)
     endif
   endif
 endif
+
+ifeq ($(filter signed-integer-overflow integer undefined,$(my_sanitize)),)
+  ifeq ($(filter -ftrapv,$(my_cflags)),)
+    my_cflags += -fwrapv
+  endif
+endif

--- a/core/dex_preopt_config.mk
+++ b/core/dex_preopt_config.mk
@@ -18,7 +18,9 @@ else ifeq (true,$(DISABLE_PREOPT))
 endif
 
 # The default value for LOCAL_DEX_PREOPT
-DEX_PREOPT_DEFAULT ?= $(ENABLE_PREOPT)
+DEX_PREOPT_DEFAULT := true
+
+WITH_DEXPREOPT_BOOT_IMG_AND_SYSTEM_SERVER_ONLY := false
 
 # Whether to fail immediately if verify_uses_libraries check fails, or to keep
 # going and restrict dexpreopt to not compile any code for the failed module.
@@ -50,25 +52,17 @@ SYSTEM_OTHER_ODEX_FILTER ?= \
 # Global switch to control if updatable boot jars are included in dexpreopt.
 DEX_PREOPT_WITH_UPDATABLE_BCP := true
 
-# Conditional to building on linux, as dex2oat currently does not work on darwin.
-ifeq ($(HOST_OS),linux)
-  ifeq (eng,$(TARGET_BUILD_VARIANT))
-    # For an eng build only pre-opt the boot image and system server. This gives reasonable performance
-    # and still allows a simple workflow: building in frameworks/base and syncing.
-    WITH_DEXPREOPT_BOOT_IMG_AND_SYSTEM_SERVER_ONLY ?= true
-  endif
-  # Add mini-debug-info to the boot classpath unless explicitly asked not to.
-  ifneq (false,$(WITH_DEXPREOPT_DEBUG_INFO))
-    PRODUCT_DEX_PREOPT_BOOT_FLAGS += --generate-mini-debug-info
-  endif
+# Add mini-debug-info to the boot classpath unless explicitly asked not to.
+ifneq (false,$(WITH_DEXPREOPT_DEBUG_INFO))
+  PRODUCT_DEX_PREOPT_BOOT_FLAGS += --generate-mini-debug-info
+endif
 
-  # Non eng linux builds must have preopt enabled so that system server doesn't run as interpreter
-  # only. b/74209329
-  ifeq (,$(filter eng, $(TARGET_BUILD_VARIANT)))
-    ifneq (true,$(WITH_DEXPREOPT))
-      ifneq (true,$(WITH_DEXPREOPT_BOOT_IMG_AND_SYSTEM_SERVER_ONLY))
-        $(call pretty-error, DEXPREOPT must be enabled for user and userdebug builds)
-      endif
+# Non eng builds must have preopt enabled so that system server doesn't run as interpreter
+# only. b/74209329
+ifeq (,$(filter eng, $(TARGET_BUILD_VARIANT)))
+  ifneq (true,$(WITH_DEXPREOPT))
+    ifneq (true,$(WITH_DEXPREOPT_BOOT_IMG_AND_SYSTEM_SERVER_ONLY))
+      $(call pretty-error, DEXPREOPT must be enabled for user and userdebug builds)
     endif
   endif
 endif

--- a/core/envsetup.mk
+++ b/core/envsetup.mk
@@ -155,10 +155,6 @@ ifeq ($(HOST_OS),linux)
     # We can only create static host binaries for Linux, so if static host
     # binaries are requested, turn off Windows cross-builds.
     ifeq ($(BUILD_HOST_static),)
-      HOST_CROSS_OS := windows
-      HOST_CROSS_ARCH := x86
-      HOST_CROSS_2ND_ARCH := x86_64
-      2ND_HOST_CROSS_IS_64_BIT := true
     endif
   else ifeq ($(HOST_CROSS_OS),linux_bionic)
     ifeq (,$(HOST_CROSS_ARCH))

--- a/core/main.mk
+++ b/core/main.mk
@@ -374,6 +374,7 @@ ifneq (,$(user_variant))
   # Target is secure in user builds.
   ADDITIONAL_SYSTEM_PROPERTIES += ro.secure=1
   ADDITIONAL_SYSTEM_PROPERTIES += security.perf_harden=1
+  ADDITIONAL_SYSTEM_PROPERTIES += ro.control_privapp_permissions=enforce
 
   ifeq ($(user_variant),user)
     ADDITIONAL_SYSTEM_PROPERTIES += ro.adb.secure=1

--- a/core/main.mk
+++ b/core/main.mk
@@ -376,6 +376,7 @@ ifneq (,$(user_variant))
   ADDITIONAL_SYSTEM_PROPERTIES += security.perf_harden=1
   ADDITIONAL_SYSTEM_PROPERTIES += ro.control_privapp_permissions=enforce
   ADDITIONAL_SYSTEM_PROPERTIES += persist.security.deny_new_usb=dynamic
+  ADDITIONAL_SYSTEM_PROPERTIES += net.tethering.noprovisioning=true
 
   ifeq ($(user_variant),user)
     ADDITIONAL_SYSTEM_PROPERTIES += ro.adb.secure=1

--- a/core/main.mk
+++ b/core/main.mk
@@ -375,6 +375,7 @@ ifneq (,$(user_variant))
   ADDITIONAL_SYSTEM_PROPERTIES += ro.secure=1
   ADDITIONAL_SYSTEM_PROPERTIES += security.perf_harden=1
   ADDITIONAL_SYSTEM_PROPERTIES += ro.control_privapp_permissions=enforce
+  ADDITIONAL_SYSTEM_PROPERTIES += persist.security.deny_new_usb=dynamic
 
   ifeq ($(user_variant),user)
     ADDITIONAL_SYSTEM_PROPERTIES += ro.adb.secure=1

--- a/core/main.mk
+++ b/core/main.mk
@@ -53,7 +53,7 @@ $(KATI_obsolete_var BUILD_NUMBER,See https://android.googlesource.com/platform/b
 $(BUILD_NUMBER_FILE):
 	touch $@
 
-DATE_FROM_FILE := date -d @$(BUILD_DATETIME_FROM_FILE)
+DATE_FROM_FILE := date -ud @$(BUILD_DATETIME_FROM_FILE)
 .KATI_READONLY := DATE_FROM_FILE
 
 # Pick a reasonable string to use to identify files.

--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -303,6 +303,6 @@ ifndef PLATFORM_MIN_SUPPORTED_TARGET_SDK_VERSION
   # Used to set minimum supported target sdk version. Apps targeting sdk
   # version lower than the set value will result in a warning being shown
   # when any activity from the app is started.
-  PLATFORM_MIN_SUPPORTED_TARGET_SDK_VERSION := 23
+  PLATFORM_MIN_SUPPORTED_TARGET_SDK_VERSION := 28
 endif
 .KATI_READONLY := PLATFORM_MIN_SUPPORTED_TARGET_SDK_VERSION

--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -275,7 +275,7 @@ ifndef BUILD_DATETIME
   BUILD_DATETIME := $(shell date +%s)
 endif
 
-DATE := date -d @$(BUILD_DATETIME)
+DATE := date -ud @$(BUILD_DATETIME)
 .KATI_READONLY := DATE
 
 # Everything should be using BUILD_DATETIME_FROM_FILE instead.

--- a/target/board/BoardConfigMainlineCommon.mk
+++ b/target/board/BoardConfigMainlineCommon.mk
@@ -28,10 +28,6 @@ TARGET_USES_64_BIT_BINDER := true
 # 64 bit mediadrmserver
 TARGET_ENABLE_MEDIADRM_64 := true
 
-# Puts odex files on system_other, as well as causing dex files not to get
-# stripped from APKs.
-BOARD_USES_SYSTEM_OTHER_ODEX := true
-
 # Audio: must using XML format for Treblized devices
 USE_XML_AUDIO_POLICY_CONF := 1
 

--- a/target/board/BoardConfigPixelCommon.mk
+++ b/target/board/BoardConfigPixelCommon.mk
@@ -16,3 +16,6 @@ BOARD_AVB_ODM_ADD_HASHTREE_FOOTER_ARGS += --hash_algorithm sha256
 # vendor_dlkm and odm_dlkm.
 BOARD_AVB_VENDOR_DLKM_ADD_HASHTREE_FOOTER_ARGS += --hash_algorithm sha256
 BOARD_AVB_ODM_DLKM_ADD_HASHTREE_FOOTER_ARGS += --hash_algorithm sha256
+
+# temporary hack for APV
+BUILD_BROKEN_ELF_PREBUILT_PRODUCT_COPY_FILES := true

--- a/target/product/aosp_base_telephony.mk
+++ b/target/product/aosp_base_telephony.mk
@@ -16,4 +16,5 @@
 $(call inherit-product, $(SRC_TARGET_DIR)/product/full_base_telephony.mk)
 
 PRODUCT_PACKAGES += \
-    messaging
+    messaging \
+    Stk

--- a/target/product/aosp_product.mk
+++ b/target/product/aosp_product.mk
@@ -26,6 +26,7 @@ PRODUCT_PRODUCT_PROPERTIES += \
     ro.config.ringtone?=Ring_Synth_04.ogg \
     ro.config.notification_sound?=pixiedust.ogg \
     ro.com.android.dataroaming?=true \
+    ro.boot.vendor.overlay.theme=com.android.internal.systemui.navbar.gestural
 
 # More AOSP packages
 PRODUCT_PACKAGES += \

--- a/target/product/aosp_product.mk
+++ b/target/product/aosp_product.mk
@@ -32,7 +32,6 @@ PRODUCT_PACKAGES += \
     messaging \
     PhotoTable \
     preinstalled-packages-platform-aosp-product.xml \
-    WallpaperPicker \
 
 # Telephony:
 #   Provide a APN configuration to GSI product

--- a/target/product/aosp_product.mk
+++ b/target/product/aosp_product.mk
@@ -32,8 +32,3 @@ PRODUCT_PACKAGES += \
     messaging \
     PhotoTable \
     preinstalled-packages-platform-aosp-product.xml \
-
-# Telephony:
-#   Provide a APN configuration to GSI product
-PRODUCT_COPY_FILES += \
-    device/sample/etc/apns-full-conf.xml:$(TARGET_COPY_OUT_PRODUCT)/etc/apns-conf.xml

--- a/target/product/full_base_telephony.mk
+++ b/target/product/full_base_telephony.mk
@@ -24,7 +24,6 @@ PRODUCT_VENDOR_PROPERTIES := \
     ro.com.android.dataroaming?=true
 
 PRODUCT_COPY_FILES := \
-    device/sample/etc/apns-full-conf.xml:system/etc/apns-conf.xml \
     frameworks/native/data/etc/handheld_core_hardware.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/handheld_core_hardware.xml
 
 $(call inherit-product, $(SRC_TARGET_DIR)/product/aosp_base.mk)

--- a/target/product/generic_system.mk
+++ b/target/product/generic_system.mk
@@ -21,9 +21,6 @@ $(call inherit-product, $(SRC_TARGET_DIR)/product/languages_default.mk)
 # Add adb keys to debuggable AOSP builds (if they exist)
 $(call inherit-product-if-exists, vendor/google/security/adb/vendor_key.mk)
 
-# Enable updating of APEXes
-$(call inherit-product, $(SRC_TARGET_DIR)/product/updatable_apex.mk)
-
 # Shared java libs
 PRODUCT_PACKAGES += \
     com.android.nfc_extras \

--- a/target/product/generic_system.mk
+++ b/target/product/generic_system.mk
@@ -113,7 +113,7 @@ PRODUCT_COPY_FILES += \
 # Enable dynamic partition size
 PRODUCT_USE_DYNAMIC_PARTITION_SIZE := true
 
-PRODUCT_ENFORCE_RRO_TARGETS := *
+#PRODUCT_ENFORCE_RRO_TARGETS := *
 
 PRODUCT_NAME := generic_system
 PRODUCT_BRAND := generic

--- a/target/product/generic_system.mk
+++ b/target/product/generic_system.mk
@@ -21,6 +21,9 @@ $(call inherit-product, $(SRC_TARGET_DIR)/product/languages_default.mk)
 # Add adb keys to debuggable AOSP builds (if they exist)
 $(call inherit-product-if-exists, vendor/google/security/adb/vendor_key.mk)
 
+# Enable updating of APEXes
+$(call inherit-product, $(SRC_TARGET_DIR)/product/updatable_apex.mk)
+
 # Shared java libs
 PRODUCT_PACKAGES += \
     com.android.nfc_extras \

--- a/target/product/handheld_product.mk
+++ b/target/product/handheld_product.mk
@@ -22,6 +22,7 @@ $(call inherit-product, $(SRC_TARGET_DIR)/product/media_product.mk)
 
 # /product packages
 PRODUCT_PACKAGES += \
+    Auditor \
     Browser2 \
     Calendar \
     Camera2 \

--- a/target/product/handheld_product.mk
+++ b/target/product/handheld_product.mk
@@ -28,6 +28,7 @@ PRODUCT_PACKAGES += \
     Camera2 \
     Contacts \
     DeskClock \
+    ExactCalculator \
     Gallery2 \
     LatinIME \
     Music \

--- a/target/product/handheld_product.mk
+++ b/target/product/handheld_product.mk
@@ -24,7 +24,7 @@ $(call inherit-product, $(SRC_TARGET_DIR)/product/media_product.mk)
 PRODUCT_PACKAGES += \
     Auditor \
     Calendar \
-    Camera2 \
+    Camera \
     Contacts \
     DeskClock \
     ExactCalculator \

--- a/target/product/handheld_product.mk
+++ b/target/product/handheld_product.mk
@@ -41,3 +41,6 @@ PRODUCT_PACKAGES += \
 
 PRODUCT_PACKAGES_DEBUG += \
     frameworks-base-overlays-debug
+
+# Build in theming functionality
+$(call inherit-product-if-exists, themes/main.mk)

--- a/target/product/handheld_product.mk
+++ b/target/product/handheld_product.mk
@@ -32,6 +32,7 @@ PRODUCT_PACKAGES += \
     LatinIME \
     Music \
     OneTimeInitializer \
+    PdfViewer \
     preinstalled-packages-platform-handheld-product.xml \
     QuickSearchBox \
     SettingsIntelligence \

--- a/target/product/handheld_product.mk
+++ b/target/product/handheld_product.mk
@@ -23,7 +23,6 @@ $(call inherit-product, $(SRC_TARGET_DIR)/product/media_product.mk)
 # /product packages
 PRODUCT_PACKAGES += \
     Auditor \
-    Browser2 \
     Calendar \
     Camera2 \
     Contacts \
@@ -37,6 +36,7 @@ PRODUCT_PACKAGES += \
     preinstalled-packages-platform-handheld-product.xml \
     QuickSearchBox \
     SettingsIntelligence \
+    TrichromeChrome \
     frameworks-base-overlays
 
 PRODUCT_PACKAGES_DEBUG += \

--- a/target/product/handheld_product.mk
+++ b/target/product/handheld_product.mk
@@ -22,6 +22,7 @@ $(call inherit-product, $(SRC_TARGET_DIR)/product/media_product.mk)
 
 # /product packages
 PRODUCT_PACKAGES += \
+    Apps \
     Auditor \
     Calendar \
     Camera \

--- a/target/product/handheld_product.mk
+++ b/target/product/handheld_product.mk
@@ -22,7 +22,6 @@ $(call inherit-product, $(SRC_TARGET_DIR)/product/media_product.mk)
 
 # /product packages
 PRODUCT_PACKAGES += \
-    Apps \
     Auditor \
     Calendar \
     Camera \

--- a/target/product/handheld_system.mk
+++ b/target/product/handheld_system.mk
@@ -49,6 +49,7 @@ PRODUCT_PACKAGES += \
     EasterEgg \
     ExternalStorageProvider \
     FusedLocation \
+    GmsCompat \
     InputDevices \
     KeyChain \
     librs_jni \

--- a/target/product/handheld_system.mk
+++ b/target/product/handheld_system.mk
@@ -65,6 +65,7 @@ PRODUCT_PACKAGES += \
     SecureElement \
     SharedStorageBackup \
     SimAppDialog \
+    talkback \
     Telecom \
     TelephonyProvider \
     TeleService \

--- a/target/product/handheld_system_ext.mk
+++ b/target/product/handheld_system_ext.mk
@@ -25,6 +25,7 @@ PRODUCT_PACKAGES += \
     Launcher3QuickStep \
     Provision \
     Settings \
+    SetupWizard \
     StorageManager \
     SystemUI \
     WallpaperCropper \

--- a/target/product/media_product.mk
+++ b/target/product/media_product.mk
@@ -22,4 +22,4 @@ $(call inherit-product, $(SRC_TARGET_DIR)/product/base_product.mk)
 
 # /product packages
 PRODUCT_PACKAGES += \
-    webview \
+    TrichromeWebView \

--- a/target/product/media_system.mk
+++ b/target/product/media_system.mk
@@ -41,6 +41,8 @@ ifeq ($(OFFICIAL_BUILD),true)
     PRODUCT_PACKAGES += Updater
 endif
 
+PRODUCT_PACKAGES += Seedvault
+
 PRODUCT_HOST_PACKAGES += \
     fsck.f2fs \
 

--- a/target/product/media_system.mk
+++ b/target/product/media_system.mk
@@ -37,6 +37,10 @@ PRODUCT_PACKAGES += \
     requestsync \
     StatementService \
 
+ifeq ($(OFFICIAL_BUILD),true)
+    PRODUCT_PACKAGES += Updater
+endif
+
 PRODUCT_HOST_PACKAGES += \
     fsck.f2fs \
 

--- a/target/product/runtime_libart.mk
+++ b/target/product/runtime_libart.mk
@@ -95,34 +95,24 @@ PRODUCT_SYSTEM_PROPERTIES += \
 PRODUCT_SYSTEM_PROPERTIES += \
     ro.dalvik.vm.native.bridge=0
 
-# Different dexopt types for different package update/install times.
-# On eng builds, make "boot" reasons only extract for faster turnaround.
-ifeq (eng,$(TARGET_BUILD_VARIANT))
-    PRODUCT_SYSTEM_PROPERTIES += \
-        pm.dexopt.first-boot?=extract \
-        pm.dexopt.boot-after-ota?=extract
-else
-    PRODUCT_SYSTEM_PROPERTIES += \
-        pm.dexopt.first-boot?=verify \
-        pm.dexopt.boot-after-ota?=verify
-endif
-
 # Note that `cmdline` is not strictly needed but it simplifies the management
 # of compilation reason in the platform (as we have a unified, single path,
 # without exceptions).
 PRODUCT_SYSTEM_PROPERTIES += \
-    pm.dexopt.post-boot?=extract \
-    pm.dexopt.install?=speed \
-    pm.dexopt.install-fast?=skip \
-    pm.dexopt.install-bulk?=speed \
-    pm.dexopt.install-bulk-secondary?=verify \
-    pm.dexopt.install-bulk-downgraded?=verify \
-    pm.dexopt.install-bulk-secondary-downgraded?=extract \
-    pm.dexopt.bg-dexopt?=speed \
-    pm.dexopt.ab-ota?=speed \
-    pm.dexopt.inactive?=verify \
-    pm.dexopt.cmdline?=verify \
-    pm.dexopt.shared?=speed
+    pm.dexopt.first-boot=speed \
+    pm.dexopt.boot-after-ota=speed \
+    pm.dexopt.post-boot=speed \
+    pm.dexopt.install=speed \
+    pm.dexopt.install-fast=speed \
+    pm.dexopt.install-bulk=speed \
+    pm.dexopt.install-bulk-secondary=speed \
+    pm.dexopt.install-bulk-downgraded=speed \
+    pm.dexopt.install-bulk-secondary-downgraded=speed \
+    pm.dexopt.bg-dexopt=speed \
+    pm.dexopt.ab-ota=speed \
+    pm.dexopt.inactive=speed \
+    pm.dexopt.cmdline=speed \
+    pm.dexopt.shared=speed
 
 # Pass file with the list of updatable boot class path packages to dex2oat.
 PRODUCT_SYSTEM_PROPERTIES += \

--- a/target/product/runtime_libart.mk
+++ b/target/product/runtime_libart.mk
@@ -86,8 +86,8 @@ PRODUCT_PACKAGES += \
 #
 # The thermal cutoff value is currently set to THERMAL_STATUS_MODERATE.
 PRODUCT_SYSTEM_PROPERTIES += \
-    dalvik.vm.usejit=true \
-    dalvik.vm.usejitprofiles=true \
+    dalvik.vm.usejit=false \
+    dalvik.vm.usejitprofiles=false \
     dalvik.vm.dexopt.secondary=true \
     dalvik.vm.dexopt.thermal-cutoff=2 \
     dalvik.vm.appimageformat=lz4

--- a/target/product/runtime_libart.mk
+++ b/target/product/runtime_libart.mk
@@ -107,22 +107,19 @@ else
         pm.dexopt.boot-after-ota?=verify
 endif
 
-# The install filter is speed-profile in order to enable the use of
-# profiles from the dex metadata files. Note that if a profile is not provided
-# or if it is empty speed-profile is equivalent to (quicken + empty app image).
 # Note that `cmdline` is not strictly needed but it simplifies the management
 # of compilation reason in the platform (as we have a unified, single path,
 # without exceptions).
 PRODUCT_SYSTEM_PROPERTIES += \
     pm.dexopt.post-boot?=extract \
-    pm.dexopt.install?=speed-profile \
+    pm.dexopt.install?=speed \
     pm.dexopt.install-fast?=skip \
-    pm.dexopt.install-bulk?=speed-profile \
+    pm.dexopt.install-bulk?=speed \
     pm.dexopt.install-bulk-secondary?=verify \
     pm.dexopt.install-bulk-downgraded?=verify \
     pm.dexopt.install-bulk-secondary-downgraded?=extract \
-    pm.dexopt.bg-dexopt?=speed-profile \
-    pm.dexopt.ab-ota?=speed-profile \
+    pm.dexopt.bg-dexopt?=speed \
+    pm.dexopt.ab-ota?=speed \
     pm.dexopt.inactive?=verify \
     pm.dexopt.cmdline?=verify \
     pm.dexopt.shared?=speed


### PR DESCRIPTION
When needing to build tools such as aapt2, the build system automatically builds Windows binaries, which we don't need. Save time by never building Windows binaries.