### PR TITLE
don't compress APEXes

### DIFF
--- a/target/product/updatable_apex.mk
+++ b/target/product/updatable_apex.mk
@@ -22,9 +22,5 @@ ifneq ($(OVERRIDE_TARGET_FLATTEN_APEX),true)
   PRODUCT_PACKAGES += com.android.apex.cts.shim.v1_prebuilt
   PRODUCT_VENDOR_PROPERTIES := ro.apex.updatable=true
   TARGET_FLATTEN_APEX := false
-  # Use compressed apexes in pre-installed partitions.
-  # Note: this doesn't mean that all pre-installed apexes will be compressed.
-  #  Whether an apex is compressed or not is controlled at apex Soong module
-  #  via compresible property.
-  PRODUCT_COMPRESSED_APEX := true
+  PRODUCT_COMPRESSED_APEX := false
 endif


### PR DESCRIPTION
Compressed APEXes are unpacked into /data/apex/decompressed before being mounted.
When APEXes aren't updated out-of-band, this unnecessarily weakens verified boot and wastes storage space. 
On GrapheneOS, APEXes are not updated out-of-band.

For more details, see https://source.android.com/docs/core/ota/apex#compressed-apex