### PR TITLE
replace AOSP CarrierConfig with GrapheneOS CarrierConfig2

### DIFF
--- a/target/product/emulator.mk
+++ b/target/product/emulator.mk
@@ -20,7 +20,7 @@
 
 # Device modules
 PRODUCT_PACKAGES += \
-    CarrierConfig \
+    CarrierConfig2 \
 
 # need this for gles libraries to load properly
 # after moving to /vendor/lib/

--- a/target/product/telephony_system_ext.mk
+++ b/target/product/telephony_system_ext.mk
@@ -19,5 +19,5 @@
 
 # /system_ext packages
 PRODUCT_PACKAGES += \
-    CarrierConfig \
+    CarrierConfig2 \
     EmergencyInfo \


### PR DESCRIPTION
Part of a changelist:

https://github.com/GrapheneOS/platform_packages_services_Telephony/pull/6
https://github.com/muhomorr/platform_packages_providers_TelephonyProvider/commit/64a13d1e9821c39585eef2bd833c6284d58a7e98 (need to move fork from archive)
https://github.com/GrapheneOS/platform_frameworks_base/pull/394

https://github.com/GrapheneOS/device_google_coral/pull/46
https://github.com/GrapheneOS/device_google_sunfish/pull/33
https://github.com/GrapheneOS/device_google_redbull/pull/32
https://github.com/GrapheneOS/device_google_gs101/pull/32
https://github.com/GrapheneOS/device_google_gs201/pull/10

