### PR TITLE
merge script/envsetup.sh into envsetup.sh

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -1,3 +1,7 @@
+umask 022
+# use shell built-in instead of the separate program which is missing by default on some distros
+alias which='command -v'
+
 function hmm() {
 cat <<EOF
 
@@ -2003,3 +2007,16 @@ function showcommands() {
 validate_current_shell
 source_vendorsetup
 addcompletions
+
+export LANG=C.UTF-8
+export _JAVA_OPTIONS=-XX:-UsePerfData
+export BUILD_DATETIME=$(cat out/build_date.txt 2>/dev/null || date -u +%s)
+echo "BUILD_DATETIME=$BUILD_DATETIME"
+export BUILD_NUMBER=$(cat out/soong/build_number.txt 2>/dev/null || date -u -d @$BUILD_DATETIME +%Y%m%d00)
+echo "BUILD_NUMBER=$BUILD_NUMBER"
+export DISPLAY_BUILD_NUMBER=true
+export BUILD_USERNAME=grapheneos
+export BUILD_HOSTNAME=grapheneos
+
+alias adevtool='vendor/adevtool/bin/run'
+alias adto='vendor/adevtool/bin/run'


### PR DESCRIPTION
Android Studio for Platform hardcodes `source build/envsetup.sh`.

For script/envsetup.sh history, see
https://github.com/GrapheneOS/script/commits/2023090600/envsetup.sh