### PR TITLE
[android-security-13.0.0_r10] set platform security patch level to 2023-10-01

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -115,7 +115,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-    PLATFORM_SECURITY_PATCH := 2023-09-01
+    PLATFORM_SECURITY_PATCH := 2023-10-01
 endif
 
 include $(BUILD_SYSTEM)/version_util.mk


### PR DESCRIPTION
Part of a changelist:

https://github.com/GrapheneOS/platform_external_libxml2/pull/1
https://github.com/GrapheneOS/platform_frameworks_base/pull/408
https://github.com/GrapheneOS/platform_frameworks_native/pull/11
https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/189
https://github.com/GrapheneOS/platform_packages_modules_Bluetooth/pull/13
https://github.com/GrapheneOS/platform_packages_modules_Wifi/pull/11
https://github.com/GrapheneOS/platform_packages_providers_MediaProvider/pull/9
https://github.com/GrapheneOS/platform_packages_services_Telecomm/pull/2

https://github.com/GrapheneOS/platform_manifest/pull/24
https://github.com/GrapheneOS/script/pull/39