### PR TITLE
envsetup.sh: fix a cosmetic issue when cmds-for-envsetup.sh is missing

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -645,10 +645,6 @@ function maybe_source_extra_commands() {
 
     local EXTRA_CMDS_ARR=(vendor/*/"$PRODUCT"/"$SCRIPT_NAME")
 
-    [[ ${#EXTRA_CMDS_ARR[@]} == 0 ]] && {
-        return
-    }
-
     [[ ${#EXTRA_CMDS_ARR[@]} == 1 ]] || {
         echo "More than one $SCRIPT_NAME file for $PRODUCT: ${EXTRA_CMDS_ARR[*]}"
         read -s
@@ -661,6 +657,11 @@ function maybe_source_extra_commands() {
     else
         EXTRA_CMDS=${EXTRA_CMDS_ARR[0]}
     fi
+
+    [[ $EXTRA_CMDS == "vendor/*/$PRODUCT/$SCRIPT_NAME" ]] && {
+        # wildcard didn't expand, which means that SCRIPT_NAME is missing
+        return
+    }
 
     echo "============================================"
     echo "Commands from $EXTRA_CMDS:"


### PR DESCRIPTION
EXTRA_CMDS_ARR is not empty when cmds-for-envsetup.sh is missing, it contains an unexpanded wildcard.

This was harmless, since that path was invalid, it only led to a few confusing stdout lines.