### PR TITLE
set number of dex2oat processes for boot-after-ota and first-boot to 2

### DIFF
--- a/target/product/runtime_libart.mk
+++ b/target/product/runtime_libart.mk
@@ -111,7 +111,9 @@ PRODUCT_SYSTEM_PROPERTIES += \
 # without exceptions).
 PRODUCT_SYSTEM_PROPERTIES += \
     pm.dexopt.first-boot=speed \
+    pm.dexopt.first-boot.concurrency=2 \
     pm.dexopt.boot-after-ota=speed-profile \
+    pm.dexopt.boot-after-ota.concurrency=2 \
     pm.dexopt.post-boot?=speed \
     pm.dexopt.boot-after-mainline-update?=speed \
     pm.dexopt.install?=speed \


### PR DESCRIPTION
It's 1 by default.

Testing showed that boot-after-ota time is reduced almost by half for the same number of packages (from 4:40 to 2:34, around 100 packages).