### PR TITLE
Use a different target name for GrapheneOS' PdfViewer

### DIFF
--- a/target/product/handheld_product.mk
+++ b/target/product/handheld_product.mk
@@ -32,7 +32,7 @@ PRODUCT_PACKAGES += \
     Gallery2 \
     LatinIME \
     Music \
-    PdfViewer \
+    PdfViewerGOS \
     preinstalled-packages-platform-handheld-product.xml \
     SettingsIntelligence \
     ThemePicker \


### PR DESCRIPTION
AOSP uses "PdfViewer" as target name for its own pdf viewer app.

Requires https://github.com/GrapheneOS/platform_external_PdfViewer/pull/1
