### PR TITLE
set setupwizard.theme sysprop

### DIFF
--- a/target/product/base_system.mk
+++ b/target/product/base_system.mk
@@ -410,6 +410,7 @@ PRODUCT_VENDOR_PROPERTIES += ro.zygote?=zygote32
 
 PRODUCT_SYSTEM_PROPERTIES += debug.atrace.tags.enableflags=0
 PRODUCT_SYSTEM_PROPERTIES += persist.traced.enable=1
+PRODUCT_SYSTEM_PROPERTIES += setupwizard.theme=glif_v4_light
 
 # Packages included only for eng or userdebug builds, previously debug tagged
 PRODUCT_PACKAGES_DEBUG := \


### PR DESCRIPTION
adds sysprop setupwizard.theme

this fixes the style inconsistencies in sud components being used in
non-setup flow

requires: https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/242
fixes: https://github.com/GrapheneOS/os-issue-tracker/issues/3471

Without fix     | With fix 
:-------------------------:|:-------------------------:
![](https://github.com/GrapheneOS/device_generic_goldfish/assets/13469327/4be52883-fb69-4b84-9e0d-f98cf723bb1c)  |  ![](https://github.com/GrapheneOS/device_generic_goldfish/assets/13469327/0a25844c-e25d-4a46-8eea-1aee0e7b1a10)