### PR TITLE
Revert "disable memory tagging for surfaceflinger"

### DIFF
--- a/target/product/memtag-common.mk
+++ b/target/product/memtag-common.mk
@@ -28,6 +28,3 @@ PRODUCT_MEMTAG_HEAP_ASYNC_DEFAULT_INCLUDE_PATHS := \
     system/bpf \
     system/netd/netutil_wrappers \
     system/netd/server
-
-PRODUCT_MEMTAG_HEAP_EXCLUDE_PATHS := \
-    frameworks/native/services/surfaceflinger


### PR DESCRIPTION
This reverts commit 0fe333338df8c7dd91faf53571cedac67d4a1dc6.