### PR TITLE
reapply changes that depend on DeviceDiagnostics repo

### DIFF
--- a/target/product/base_system.mk
+++ b/target/product/base_system.mk
@@ -290,6 +290,7 @@ PRODUCT_PACKAGES += \
     tombstoned \
     traced \
     traced_probes \
+    tradeinmode \
     tune2fs \
     uiautomator \
     uinput \

--- a/target/product/generic/Android.bp
+++ b/target/product/generic/Android.bp
@@ -540,6 +540,7 @@ android_filesystem_defaults {
         "tombstoned", // base_system
         "traced", // base_system
         "traced_probes", // base_system
+        "tradeinmode", // base_system
         "tune2fs", // base_system
         "uiautomator", // base_system
         "uinput", // base_system

--- a/target/product/generic/Android.bp
+++ b/target/product/generic/Android.bp
@@ -631,6 +631,7 @@ android_filesystem_defaults {
                 "ContactsProvider", // base_system
                 "CredentialManager", // handheld_system
                 "DeviceAsWebcam", // handheld_system
+                "DeviceDiagnostics", // handheld_system - internal
                 "DocumentsUI", // handheld_system
                 "DownloadProvider", // base_system
                 "DownloadProviderUi", // handheld_system

--- a/target/product/handheld_system.mk
+++ b/target/product/handheld_system.mk
@@ -46,6 +46,7 @@ PRODUCT_PACKAGES += \
     CertInstaller \
     CredentialManager \
     DeviceAsWebcam \
+    DeviceDiagnostics \
     DocumentsUI \
     DownloadProviderUi \
     EasterEgg \


### PR DESCRIPTION
DeviceDiagnostics repo wasn't included in the initial android-15.0.0_r23 AOSP manifest. It's included now.