### PR TITLE
Revert "disable enforce RRO for mainline devices"

### DIFF
--- a/target/product/generic_system.mk
+++ b/target/product/generic_system.mk
@@ -122,7 +122,7 @@ PRODUCT_PACKAGES += \
 # Enable dynamic partition size
 PRODUCT_USE_DYNAMIC_PARTITION_SIZE := true
 
-#PRODUCT_ENFORCE_RRO_TARGETS := *
+PRODUCT_ENFORCE_RRO_TARGETS := *
 
 PRODUCT_NAME := generic_system
 PRODUCT_BRAND := generic


### PR DESCRIPTION
This change is no longer needed, RROs are fully supported now.