### PR TITLE
#2133 Add mic spoofing default audio asset to product packages

### DIFF
--- a/target/product/media_system.mk
+++ b/target/product/media_system.mk
@@ -41,6 +41,7 @@ ifeq ($(OFFICIAL_BUILD),true)
 endif
 
 PRODUCT_PACKAGES += Seedvault
+PRODUCT_PACKAGES += spoofed_mic_audio_default
 
 ifeq ($(RELEASE_PACKAGE_COMPUTER_CONTROL),true)
   PRODUCT_PACKAGES += VirtualDeviceManager


### PR DESCRIPTION
Implements https://github.com/GrapheneOS/os-issue-tracker/issues/2133

Adds `spoofed_mic_audio_default` to `media_system.mk` so the default spoofed WAV is installed to `/system/etc/spoofed_mic_audio_default.wav`.

Although we're currently providing silence there, it is a more universal solution to ship it as WAV instead of returning zeroes, so we can easily change this in the future.