### PR TITLE
Replace AOSP Gallery with the new Gallery app

### DIFF
--- a/target/product/handheld_product.mk
+++ b/target/product/handheld_product.mk
@@ -29,7 +29,7 @@ PRODUCT_PACKAGES += \
     Contacts \
     DeskClock \
     ExactCalculator \
-    Gallery2 \
+    Gallery \
     InfoApp \
     LatinIME \
     Music \


### PR DESCRIPTION
The app is expected in `external/Gallery`:

```
android_app_import {
    name: "Gallery",
    product_specific: true,
    privileged: false,

    arch: {
        arm64: {
            apk: "prebuilt/Gallery-arm64-v8a-release.apk",
        },
        x86_64: {
            apk: "prebuilt/Gallery-x86_64-release.apk",
        },
    },
    preprocessed: true,

    optional_uses_libs: ["androidx.window.extensions", "androidx.window.sidecar"],
}

```

Related:

https://github.com/GrapheneOS/platform_frameworks_base/pull/348