### PR TITLE
secure paste: install test helper in debug builds

### DIFF
--- a/target/product/base_system.mk
+++ b/target/product/base_system.mk
@@ -616,6 +616,7 @@ PRODUCT_PACKAGES_DEBUG := \
     unwind_reg_info \
     unwind_symbols \
     HardeningTestApp \
+    SecurePasteTestSystemApp \
 
 # The set of packages whose code can be loaded by the system server.
 PRODUCT_SYSTEM_SERVER_APPS += \


### PR DESCRIPTION
Install the SecurePasteTestSystemApp module through PRODUCT_PACKAGES_DEBUG so userdebug and eng images include the preinstalled system app needed by frameworks/base SecurePasteTests to verify the system app exemption.